### PR TITLE
Fixed recursion error when pyan.py is called in a directory with an __init__.py

### DIFF
--- a/pyan.py
+++ b/pyan.py
@@ -743,6 +743,9 @@ def get_module_name(filename):
     
     if not os.path.exists(init_path):
         return mod_name
+
+    if not os.path.dirname(filename):
+        return mod_name
     
     return get_module_name(os.path.dirname(filename)) + '.' + mod_name
 


### PR DESCRIPTION
If running pyan.py in a directory which contains an `__init__.py`, a recursion error occurs inside `get_module_name` with `get_module_name('')` recursively calling itself.

e.g. for the following folder structure:
```
foo/
    __init__.py
    bar.py
__init__.py
```

with the following call in the root directory:
`python pyan.py foo/*.py --dot`

`get_module_name` then gets called with the following arguments:
```
get_module_name('foo/bar.py')
--> get_module_name('foo')        # 1. this step should return 'foo' rather than recurse
    --> get_module_name('')
        -->get_module_name('')    # 2. recursion error
            ...
```

Existing behaviour is 2. New behaviour is 1.