### PR TITLE
Commandline option for dot graph direction (rankdir)

### DIFF
--- a/pyan.py
+++ b/pyan.py
@@ -743,6 +743,9 @@ def get_module_name(filename):
     
     if not os.path.exists(init_path):
         return mod_name
+
+    if not os.path.dirname(filename):
+        return mod_name
     
     return get_module_name(os.path.dirname(filename)) + '.' + mod_name
 


### PR DESCRIPTION
Merge after #2 

Adds a commandline option to control the default direction for top level nodes in dot. Useful for generating graphs for a directory of scripts (i.e. many top level nodes).