### PR TITLE
Fix tgf output

### DIFF
--- a/pyan.py
+++ b/pyan.py
@@ -2,7 +2,7 @@
 
 """
     pyan.py - Generate approximate call graphs for Python programs.
-    
+
     This program takes one or more Python source files, does a superficial
     analysis, and constructs a directed graph of the objects in the combined
     source, and how they define or use each other.  The graph can be output
@@ -147,25 +147,25 @@ class Node(object):
     If the namespace is Null, it is rendered as *, and considered as an unknown
     node.  The meaning of this is that a use-edge to an unknown node is created
     when the analysis cannot determine which actual node is being used."""
-    
+
     def __init__(self, namespace, name, orig_node):
         self.namespace = namespace
         self.name = name
         self.defined = namespace is None
         self.orig_node = orig_node
-    
+
     def get_short_name(self):
         """Return the short name (i.e. excluding the namespace), of this Node.
         Names of unknown nodes will include the *. prefix."""
-        
+
         if self.namespace is None:
             return '*.' + self.name
         else:
             return self.name
-    
+
     def get_name(self):
         """Return the full name of this node."""
-        
+
         if self.namespace == '':
             return self.name
         elif self.namespace is None:
@@ -200,9 +200,9 @@ class Node(object):
         """Return a label for this node, suitable for use in graph formats.
         Unique nodes should have unique labels; and labels should not contain
         problematic characters like dots or asterisks."""
-        
+
         return self.get_name().replace('.', '__').replace('*', '')
-    
+
     def __repr__(self):
         return '<Node %s>' % self.get_name()
 
@@ -210,7 +210,7 @@ class Node(object):
 class CallGraphVisitor(object):
     """A visitor that can be walked over a Python AST, and will derive
     information about the objects in the AST and how they use each other.
-    
+
     A single CallGraphVisitor object can be run over several ASTs (from a
     set of source files).  The resulting information is the aggregate from
     all files.  This way use information between objects in different files
@@ -224,7 +224,7 @@ class CallGraphVisitor(object):
         self.scope_stack = []
         self.last_value = None
         self.current_class = None
-    
+
     def visitModule(self, node):
         self.name_stack.append(self.module_name)
         self.scope_stack.append(self.scopes[node])
@@ -232,15 +232,15 @@ class CallGraphVisitor(object):
         self.scope_stack.pop()
         self.name_stack.pop()
         self.last_value = None
-    
+
     def visitClass(self, node):
         from_node = self.get_current_namespace()
         to_node = self.get_node(from_node.get_name(), node.name, node)
         if self.add_defines_edge(from_node, to_node):
             verbose_output("Def from %s to Class %s" % (from_node, to_node))
-        
+
         self.current_class = to_node
-        
+
         self.name_stack.append(node.name)
         self.scope_stack.append(self.scopes[node])
         for b in node.bases:
@@ -248,19 +248,19 @@ class CallGraphVisitor(object):
         self.visit(node.code)
         self.scope_stack.pop()
         self.name_stack.pop()
-        
+
     def visitFunction(self, node):
         if node.name == '__init__':
             for d in node.defaults:
                 self.visit(d)
             self.visit(node.code)
             return
-        
+
         from_node = self.get_current_namespace()
         to_node = self.get_node(from_node.get_name(), node.name, node)
         if self.add_defines_edge(from_node, to_node):
             verbose_output("Def from %s to Function %s" % (from_node, to_node))
-        
+
         self.name_stack.append(node.name)
         self.scope_stack.append(self.scopes[node])
         for d in node.defaults:
@@ -268,7 +268,7 @@ class CallGraphVisitor(object):
         self.visit(node.code)
         self.scope_stack.pop()
         self.name_stack.pop()
-        
+
     def visitImport(self, node):
         for import_item in node.names:
             tgt_name = import_item[0].split('.', 1)[0]
@@ -276,21 +276,21 @@ class CallGraphVisitor(object):
             to_node = self.get_node('', tgt_name, node)
             if self.add_uses_edge(from_node, to_node):
                 verbose_output("Use from %s to Import %s" % (from_node, to_node))
-            
+
             if tgt_name in self.module_names:
                 mod_name = self.module_names[tgt_name]
             else:
                 mod_name = tgt_name
             tgt_module = self.get_node('', mod_name, node)
             self.set_value(tgt_name, tgt_module)
-        
+
     def visitFrom(self, node):
         tgt_name = node.modname
         from_node = self.get_current_namespace()
         to_node = self.get_node(None, tgt_name, node)
         if self.add_uses_edge(from_node, to_node):
             verbose_output("Use from %s to From %s" % (from_node, to_node))
-        
+
         if tgt_name in self.module_names:
             mod_name = self.module_names[tgt_name]
         else:
@@ -301,56 +301,56 @@ class CallGraphVisitor(object):
             tgt_module = self.get_node(mod_name, name, node)
             self.set_value(new_name, tgt_module)
             verbose_output("From setting name %s to %s" % (new_name, tgt_module))
-    
+
     def visitConst(self, node):
         t = type(node.value)
         tn = t.__name__
         self.last_value = self.get_node('', tn, node)
-    
+
     def visitAssAttr(self, node):
         save_last_value = self.last_value
         self.visit(node.expr)
-        
+
         if isinstance(self.last_value, Node) and self.last_value.orig_node in self.scopes:
             sc = self.scopes[self.last_value.orig_node]
             sc.defs[node.attrname] = save_last_value
             verbose_output('assattr %s on %s to %s' % (node.attrname, self.last_value, save_last_value))
-        
+
         self.last_value = save_last_value
-    
+
     def visitAssName(self, node):
         tgt_name = node.name
         self.set_value(tgt_name, self.last_value)
-    
+
     def visitAssign(self, node):
         self.visit(node.expr)
-        
+
         for ass in node.nodes:
             self.visit(ass)
-        
+
         self.last_value = None
-    
+
     def visitCallFunc(self, node):
         self.visit(node.node)
-        
+
         for arg in node.args:
             self.visit(arg)
-        
+
         if node.star_args is not None:
             self.visit(node.star_args)
         if node.dstar_args is not None:
             self.visit(node.dstar_args)
-    
+
     def visitDiscard(self, node):
         self.visit(node.expr)
         self.last_value = None
-    
+
     def visitName(self, node):
         if node.name == 'self' and self.current_class is not None:
             verbose_output('name %s is maps to %s' % (node.name, self.current_class))
             self.last_value = self.current_class
             return
-        
+
         tgt_name = node.name
         from_node = self.get_current_namespace()
         to_node = self.get_value(tgt_name)
@@ -360,17 +360,17 @@ class CallGraphVisitor(object):
             to_node = self.get_node(None, tgt_name, node)
         if self.add_uses_edge(from_node, to_node):
             verbose_output("Use from %s to Name %s" % (from_node, to_node))
-        
+
         self.last_value = to_node
-   
+
     def visitGetattr(self, node):
         self.visit(node.expr)
-        
+
         if isinstance(self.last_value, Node) and self.last_value.orig_node in self.scopes and node.attrname in self.scopes[self.last_value.orig_node].defs:
             verbose_output('getattr %s from %s returns %s' % (node.attrname, self.last_value, self.scopes[self.last_value.orig_node].defs[node.attrname]))
             self.last_value = self.scopes[self.last_value.orig_node].defs[node.attrname]
             return
-        
+
         tgt_name = node.attrname
         from_node = self.get_current_namespace()
         if isinstance(self.last_value, Node) and self.last_value.namespace is not None:
@@ -379,37 +379,37 @@ class CallGraphVisitor(object):
             to_node = self.get_node(None, tgt_name, node)
         if self.add_uses_edge(from_node, to_node):
             verbose_output("Use from %s to Getattr %s" % (from_node, to_node))
-        
+
         self.last_value = to_node
-    
+
     def get_node(self, namespace, name, orig_node=None):
         """Return the unique node matching the namespace and name.
         Creates a new node if one doesn't already exist."""
-        
+
         if name in self.nodes:
             for n in self.nodes[name]:
                 if n.namespace == namespace:
                     return n
-        
+
         n = Node(namespace, name, orig_node)
-        
+
         if name in self.nodes:
             self.nodes[name].append(n)
         else:
             self.nodes[name] = [n]
-        
+
         return n
-    
+
     def get_current_namespace(self):
         """Return a node representing the current namespace."""
-        
+
         namespace = '.'.join(self.name_stack[0:-1])
         name = self.name_stack[-1]
         return self.get_node(namespace, name, None)
 
     def find_scope(self, name):
         """Search in the scope stack for the top-most scope containing name."""
-        
+
         for sc in reversed(self.scope_stack):
             if name in sc.defs:
                 return sc
@@ -417,7 +417,7 @@ class CallGraphVisitor(object):
 
     def get_value(self, name):
         """Get the value of name in the current scope."""
-        
+
         sc = self.find_scope(name)
         if sc is None:
             return None
@@ -425,10 +425,10 @@ class CallGraphVisitor(object):
         if isinstance(value, Node):
             return value
         return None
-    
+
     def set_value(self, name, value):
         """Set the value of name in the current scope."""
-        
+
         sc = self.find_scope(name)
         if sc is not None and isinstance(value, Node):
             sc.defs[name] = value
@@ -437,7 +437,7 @@ class CallGraphVisitor(object):
     def add_defines_edge(self, from_node, to_node):
         """Add a defines edge in the graph between two nodes.
         N.B. This will mark both nodes as defined."""
-        
+
         if from_node not in self.defines_edges:
             self.defines_edges[from_node] = set()
         if to_node in self.defines_edges[from_node]:
@@ -446,20 +446,20 @@ class CallGraphVisitor(object):
         from_node.defined = True
         to_node.defined = True
         return True
-    
+
     def add_uses_edge(self, from_node, to_node):
         """Add a uses edge in the graph between two nodes."""
-        
+
         if from_node not in self.uses_edges:
             self.uses_edges[from_node] = set()
         if to_node in self.uses_edges[from_node]:
             return False
         self.uses_edges[from_node].add(to_node)
         return True
-    
+
     def contract_nonexistents(self):
         """For all use edges to non-existent (i.e. not defined nodes) X.name, replace with edge to *.name."""
-        
+
         new_uses_edges = []
         for n in self.uses_edges:
             for n2 in self.uses_edges[n]:
@@ -467,41 +467,41 @@ class CallGraphVisitor(object):
                     n3 = self.get_node(None, n2.name, n2.orig_node)
                     new_uses_edges.append((n, n3))
                     verbose_output("Contracting non-existent from %s to %s" % (n, n2))
-        
+
         for from_node, to_node in new_uses_edges:
             self.add_uses_edge(from_node, to_node)
-    
+
     def expand_unknowns(self):
         """For each unknown node *.name, replace all its incoming edges with edges to X.name for all possible Xs."""
-        
+
         new_defines_edges = []
         for n in self.defines_edges:
             for n2 in self.defines_edges[n]:
                 if n2.namespace is None:
                     for n3 in self.nodes[n2.name]:
                         new_defines_edges.append((n, n3))
-        
+
         for from_node, to_node in new_defines_edges:
             self.add_defines_edge(from_node, to_node)
-        
+
         new_uses_edges = []
         for n in self.uses_edges:
             for n2 in self.uses_edges[n]:
                 if n2.namespace is None:
                     for n3 in self.nodes[n2.name]:
                         new_uses_edges.append((n, n3))
-        
+
         for from_node, to_node in new_uses_edges:
             self.add_uses_edge(from_node, to_node)
-        
+
         for name in self.nodes:
             for n in self.nodes[name]:
                 if n.namespace is None:
                     n.defined = False
-    
+
     def cull_inherited(self):
         """For each use edge from W to X.name, if it also has an edge to W to Y.name where Y is used by X, then remove the first edge."""
-        
+
         removed_uses_edges = []
         for n in self.uses_edges:
             for n2 in self.uses_edges[n]:
@@ -520,14 +520,14 @@ class CallGraphVisitor(object):
                         pn3 = self.get_node(nsp3, p3, None)
                         if pn2 in self.uses_edges and pn3 in self.uses_edges[pn2]:
                             inherited = True
-                
+
                 if inherited and n in self.uses_edges:
                     removed_uses_edges.append((n, n2))
                     verbose_output("Removing inherited edge from %s to %s" % (n, n2))
-        
+
         for from_node, to_node in removed_uses_edges:
             self.uses_edges[from_node].remove(to_node)
-    
+
     def to_dot(self, **kwargs):
         draw_defines = ("draw_defines" in kwargs  and  kwargs["draw_defines"])
         draw_uses = ("draw_uses" in kwargs  and  kwargs["draw_uses"])
@@ -549,7 +549,7 @@ class CallGraphVisitor(object):
         #   0 = pure red
         #  60 = pure yellow
         # 120 = pure green
-        # 180 = pure cyan 
+        # 180 = pure cyan
         # 240 = pure blue
         # 300 = pure magenta
         #
@@ -700,7 +700,7 @@ class CallGraphVisitor(object):
         s += """}\n"""  # terminate "digraph G {"
         return s
 
-    
+
     def to_tgf(self, **kwargs):
         draw_defines = ("draw_defines" in kwargs  and  kwargs["draw_defines"])
         draw_uses = ("draw_uses" in kwargs  and  kwargs["draw_uses"])
@@ -716,9 +716,9 @@ class CallGraphVisitor(object):
                     i += 1
                 #else:
                 #    print >>sys.stderr, "ignoring %s" % n
-        
+
         s += """#\n"""
-        
+
         if draw_defines:
             for n in self.defines_edges:
                 for n2 in self.defines_edges[n]:
@@ -740,19 +740,19 @@ class CallGraphVisitor(object):
 def get_module_name(filename):
     """Try to determine the full module name of a source file, by figuring out
     if its directory looks like a package (i.e. has an __init__.py file)."""
-    
+
     if os.path.basename(filename) == '__init__.py':
         return get_module_name(os.path.dirname(filename))
-    
+
     init_path = os.path.join(os.path.dirname(filename), '__init__.py')
     mod_name = os.path.basename(filename).replace('.py', '')
-    
+
     if not os.path.exists(init_path):
         return mod_name
 
     if not os.path.dirname(filename):
         return mod_name
-    
+
     return get_module_name(os.path.dirname(filename)) + '.' + mod_name
 
 
@@ -805,20 +805,20 @@ def main():
 
     if options.nested_groups:
         options.grouped = True
-    
+
     if not options.verbose:
         global verbose_output
         verbose_output = lambda msg: None
-    
+
     v = CallGraphVisitor()
     v.module_names = {}
-    
+
     # First find module full names for all files
     for filename in filenames:
         mod_name = get_module_name(filename)
         short_name = mod_name.rsplit('.', 1)[-1]
         v.module_names[short_name] = mod_name
-    
+
     # Process the set of files, TWICE: so that forward references are picked up
     for filename in filenames + filenames:
         ast = compiler.parseFile(filename)
@@ -828,11 +828,11 @@ def main():
         compiler.walk(ast, s)
         v.scopes = s.scopes
         compiler.walk(ast, v)
-    
+
     v.contract_nonexistents()
     v.expand_unknowns()
     v.cull_inherited()
-    
+
     if options.dot:
         print v.to_dot(draw_defines=options.draw_defines,
                        draw_uses=options.draw_uses,

--- a/pyan.py
+++ b/pyan.py
@@ -710,12 +710,9 @@ class CallGraphVisitor(object):
         id_map = {}
         for name in self.nodes:
             for n in self.nodes[name]:
-                if n.defined:
-                    s += """%d %s\n""" % (i, n.get_short_name())
-                    id_map[n] = i
-                    i += 1
-                #else:
-                #    print >>sys.stderr, "ignoring %s" % n
+                s += """%d %s\n""" % (i, n.get_short_name())
+                id_map[n] = i
+                i += 1
 
         s += """#\n"""
 


### PR DESCRIPTION
Using `--tgf` output format seems to break on trivial examples.

e.g. 

`a.py`:
```
import b
b.c()
```

`b.py`:
```
def c():
    pass
```

Results in:
```
$ ./pyan.py a.py b.py --tgf
Traceback (most recent call last):
  File "./pyan.py", line 849, in <module>
    main()
  File "./pyan.py", line 845, in main
    draw_uses=options.draw_uses)
  File "./pyan.py", line 734, in to_tgf
    i1 = id_map[n]
KeyError: <Node a>
```

By removing the `if n.defined:` check on line 713, this succeeds.

(The rest of this diff is just trailing whitespace removal noise)