### PR TITLE
Fix labels for filenames containing '-'

### DIFF
--- a/pyan/node.py
+++ b/pyan/node.py
@@ -12,7 +12,7 @@ def make_safe_label(label):
     out = label
     for word in unsafe_words:
         out = out.replace(word, "%sX" % word)
-    return out.replace(".", "__").replace("*", "")
+    return out.replace(".", "__").replace("*", "").replace("-", "_")
 
 
 class Flavor(Enum):


### PR DESCRIPTION
dot errors out if a label / filename contains a '-'.
Replace it with '_'.